### PR TITLE
fix: some small issues found during testing

### DIFF
--- a/converters/migration_context.py
+++ b/converters/migration_context.py
@@ -19,6 +19,19 @@ class MigrationContext:
         self.user_uploads_bucket_name: str | None = None
         self.workspace_bucket_name: str | None = None
 
+        # S3 bucket expirations
+        self.binaries_bucket_expiration_days: str | None = None
+        self.deliveries_bucket_expiration_days: str | None = None
+        self.large_queue_name: str | None = None
+        self.metadata_bucket_expiration_days: str | None = None
+        self.modules_bucket_expiration_days: str | None = None
+        self.policy_bucket_expiration_days: str | None = None
+        self.run_logs_bucket_expiration_days: str | None = None
+        self.states_bucket_expiration_days: str | None = None
+        self.uploads_bucket_expiration_days: str | None = None
+        self.user_uploads_bucket_expiration_days: str | None = None
+        self.workspace_bucket_expiration_days: str | None = None
+
         # S3 replication configuration
         self.s3_replication_role_name: str | None = None
         self.s3_replication_policy_name: str | None = None

--- a/converters/s3_to_terraform.py
+++ b/converters/s3_to_terraform.py
@@ -166,6 +166,7 @@ class S3Terraformer(Terraformer):
     def s3_to_terraform(
         self,
         bucketName,
+        bucketExpirationDays,
         versioning_enabled,
         sse_enabled,
         lifecycle_enabled,
@@ -175,6 +176,7 @@ class S3Terraformer(Terraformer):
     ):
         if "downloads" in bucketName:  # In v2 we called it downloads, in v3 we call it binaries
             self.migration_context.binaries_bucket_name = bucketName
+            self.migration_context.binaries_bucket_expiration_days = bucketExpirationDays
             self.process(self.binaries_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.binaries_versioning_resource_name, bucketName)
@@ -183,6 +185,7 @@ class S3Terraformer(Terraformer):
 
         elif "deliveries" in bucketName:
             self.migration_context.deliveries_bucket_name = bucketName
+            self.migration_context.deliveries_bucket_expiration_days = bucketExpirationDays
             self.process(self.deliveries_resource_name, bucketName)
             if sse_enabled:
                 self.process(self.deliveries_encryption_resource_name, bucketName)
@@ -193,6 +196,7 @@ class S3Terraformer(Terraformer):
 
         elif "large-queue" in bucketName:
             self.migration_context.large_queue_name = bucketName
+            self.migration_context.large_queue_bucket_expiration_days = bucketExpirationDays
             self.process(self.large_queue_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.large_queue_versioning_resource_name, bucketName)
@@ -205,6 +209,7 @@ class S3Terraformer(Terraformer):
 
         elif "metadata" in bucketName:
             self.migration_context.metadata_bucket_name = bucketName
+            self.migration_context.metadata_bucket_expiration_days = bucketExpirationDays
             self.process(self.metadata_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.metadata_versioning_resource_name, bucketName)
@@ -217,6 +222,7 @@ class S3Terraformer(Terraformer):
 
         elif "modules" in bucketName:
             self.migration_context.modules_bucket_name = bucketName
+            self.migration_context.modules_bucket_expiration_days = bucketExpirationDays
             self.process(self.modules_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.modules_versioning_resource_name, bucketName)
@@ -237,6 +243,7 @@ class S3Terraformer(Terraformer):
 
         elif "policy-inputs" in bucketName:
             self.migration_context.policy_bucket_name = bucketName
+            self.migration_context.policy_bucket_expiration_days = bucketExpirationDays
             self.process(self.policy_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.policy_versioning_resource_name, bucketName)
@@ -257,6 +264,7 @@ class S3Terraformer(Terraformer):
 
         elif "run-logs" in bucketName:
             self.migration_context.run_logs_bucket_name = bucketName
+            self.migration_context.run_logs_bucket_expiration_days = bucketExpirationDays
             self.process(self.run_logs_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.run_logs_versioning_resource_name, bucketName)
@@ -277,6 +285,7 @@ class S3Terraformer(Terraformer):
 
         elif "states" in bucketName:
             self.migration_context.states_bucket_name = bucketName
+            self.migration_context.states_bucket_expiration_days = bucketExpirationDays
             self.process(self.states_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.states_versioning_resource_name, bucketName)
@@ -294,6 +303,7 @@ class S3Terraformer(Terraformer):
                 )
         elif "uploads" in bucketName:
             self.migration_context.uploads_bucket_name = bucketName
+            self.migration_context.uploads_bucket_expiration_days = bucketExpirationDays
             self.process(self.uploads_resource_name, bucketName)
             for rule in cors_rules:
                 allowed_origins = rule.get("AllowedOrigins", [])
@@ -311,6 +321,7 @@ class S3Terraformer(Terraformer):
 
         elif "user-uploaded-workspaces" in bucketName:
             self.migration_context.user_uploads_bucket_name = bucketName
+            self.migration_context.user_uploads_bucket_expiration_days = bucketExpirationDays
             self.process(self.user_uploads_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.user_uploads_versioning_resource_name, bucketName)
@@ -323,6 +334,7 @@ class S3Terraformer(Terraformer):
 
         elif "workspace" in bucketName:
             self.migration_context.workspace_bucket_name = bucketName
+            self.migration_context.workspace_bucket_expiration_days = bucketExpirationDays
             self.process(self.workspace_resource_name, bucketName)
             if versioning_enabled:
                 self.process(self.workspace_versioning_resource_name, bucketName)

--- a/utils/terraform_generator.py
+++ b/utils/terraform_generator.py
@@ -142,7 +142,7 @@ def create_locals_block(context: MigrationContext) -> str:
     return f"""
 locals {{
   region            = "{context.config.aws_region}"
-  spacelift_version = "v3.0.0" # TODO: This is a tag of a Docker image uploaded to the "spacelift" and "spacelift-launcher" ECRs.
+  spacelift_version = "v3.0.0" # TODO: This is the tag of the Docker images uploaded to the "spacelift" and "spacelift-launcher" ECRs.
   website_domain    = "{context.cors_origin.replace('https://', '')}"
   website_endpoint  = "https://${{local.website_domain}}"
   license_token     = "<TODO: you need to set this value>" # This value must be set to the license token you received from Spacelift.
@@ -208,23 +208,25 @@ def create_spacelift_module(unique_suffix: str, context: MigrationContext) -> st
 
     return f"""        
 module "spacelift" {{
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.3.0"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.3.1"
 
   region           = local.region
   website_endpoint = local.website_endpoint
   unique_suffix    = "{unique_suffix}"
-  s3_bucket_names  = {{
-    binaries     = "{context.binaries_bucket_name}"
-    deliveries   = "{context.deliveries_bucket_name}"
-    large_queue  = "{context.large_queue_name}"
-    metadata     = "{context.metadata_bucket_name}"
-    modules      = "{context.modules_bucket_name}"
-    policy       = "{context.policy_bucket_name}"
-    run_logs     = "{context.run_logs_bucket_name}"
-    states       = "{context.states_bucket_name}"
-    uploads      = "{context.uploads_bucket_name}"
-    user_uploads = "{context.user_uploads_bucket_name}"
-    workspace    = "{context.workspace_bucket_name}"
+
+  # Note that certain buckets have no retention rules in place. In which case their expiration_days will be set to 0.
+  s3_bucket_configuration  = {{
+    binaries     = {{ name = "{context.binaries_bucket_name}", expiration_days = {context.binaries_bucket_expiration_days} }}
+    deliveries   = {{ name = "{context.deliveries_bucket_name}", expiration_days = {context.deliveries_bucket_expiration_days} }}
+    large_queue  = {{ name = "{context.large_queue_name}", expiration_days = {context.large_queue_bucket_expiration_days} }}
+    metadata     = {{ name = "{context.metadata_bucket_name}", expiration_days = {context.metadata_bucket_expiration_days} }}
+    modules      = {{ name = "{context.modules_bucket_name}", expiration_days = {context.modules_bucket_expiration_days} }}
+    policy       = {{ name = "{context.policy_bucket_name}", expiration_days = {context.policy_bucket_expiration_days} }}
+    run_logs     = {{ name = "{context.run_logs_bucket_name}", expiration_days = {context.run_logs_bucket_expiration_days} }}
+    states       = {{ name = "{context.states_bucket_name}", expiration_days = {context.states_bucket_expiration_days} }}
+    uploads      = {{ name = "{context.uploads_bucket_name}", expiration_days = {context.uploads_bucket_expiration_days} }}
+    user_uploads = {{ name = "{context.user_uploads_bucket_name}", expiration_days = {context.user_uploads_bucket_expiration_days} }}
+    workspace    = {{ name = "{context.workspace_bucket_name}", expiration_days = {context.workspace_bucket_expiration_days} }}
   }}
 
   kms_arn                       = aws_kms_key.master.arn


### PR DESCRIPTION
- Tweaked the README:
  - Made it more obvious that the `source` command applies to MacOS as well.
  - Added a section about uploading the latest container images to the registry.
  - Switched the `terraform` commands to `tofu`.
  - Adjusted the internet gateway section - it's actually the route tables that we're adjusting, not the gateway itself.
- Updated the Terraform generator to get the S3 bucket expiration rules. This is important if users have setup custom retention periods.

The changes to the Terraform generator rely on these changes to the Terraform infra module: https://github.com/spacelift-io/terraform-aws-spacelift-selfhosted/pull/27.