### PR TITLE
feat: add compatibility for newer TF module versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Key features:
 - Supports custom VPC configurations (where `.vpc_config.use_custom_vpc` is set to `true`)
 - Supports bi-regional disaster recovery setups
 
+## 📊 Compatibility Matrix
+
+| Spacelift version | Migration kit version | [AWS Spacelift module](https://github.com/spacelift-io/terraform-aws-spacelift-selfhosted) | [AWS ECS module](https://github.com/spacelift-io/terraform-aws-ecs-spacelift-selfhosted) |
+| ----------------- | --------------------- | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| >= 2.6.0, < 4.0.0 | 1.0.1                 | 1.3.1                                                                                      | 1.1.0                                                                                    |
+| >= 2.6.0, < 6.0.0 | 1.1.0                 | 2.1.1                                                                                      | 2.1.0                                                                                    |
+
 ## 📦 Requirements
 
 - At least Self-hosted v2.6.0 installed

--- a/converters/migration_context.py
+++ b/converters/migration_context.py
@@ -64,3 +64,5 @@ class MigrationContext:
         self.rds_preferred_backup_window: str | None = None
         self.rds_instance_identifier: str | None = None
         self.rds_instance_class: str | None = None
+        self.rds_parameter_group_name: str | None = None
+        self.rds_parameter_group_description: str | None = None

--- a/converters/rds_to_terraform.py
+++ b/converters/rds_to_terraform.py
@@ -17,7 +17,7 @@ class RDSTerraformer(Terraformer):
             "module.spacelift.module.rds[0].aws_rds_cluster_parameter_group.spacelift"
         )
 
-    def rds_to_terraform(self, cluster: dict, instance: dict):
+    def rds_to_terraform(self, cluster: dict, instance: dict, param_group: dict):
         if self.migration_context.config.uses_custom_database_connection_string():
             # The user handles their own database outside of Cloudformation
             return
@@ -26,6 +26,8 @@ class RDSTerraformer(Terraformer):
         self.migration_context.rds_preferred_backup_window = cluster["PreferredBackupWindow"]
         self.migration_context.rds_instance_identifier = instance["DBInstanceIdentifier"]
         self.migration_context.rds_instance_class = instance["DBInstanceClass"]
+        self.migration_context.rds_parameter_group_name = param_group["DBClusterParameterGroupName"]
+        self.migration_context.rds_parameter_group_description = param_group["Description"]
 
         self.process(
             self.db_subnet_group_resource_name,
@@ -38,5 +40,5 @@ class RDSTerraformer(Terraformer):
         )
         self.process(
             self.parameter_group_resource_name,
-            "spacelift",
+            self.migration_context.rds_parameter_group_name,
         )

--- a/converters/s3_to_terraform.py
+++ b/converters/s3_to_terraform.py
@@ -27,7 +27,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.deliveries"
         )
         self.deliveries_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.deliveries"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.deliveries[0]"
         )
 
         self.large_queue_resource_name = (
@@ -41,7 +41,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.large_queue_messages"
         )
         self.large_queue_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.large_queue_messages"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.large_queue_messages[0]"
         )
 
         self.metadata_resource_name = "module.spacelift.module.s3.aws_s3_bucket.metadata"
@@ -55,7 +55,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.metadata"
         )
         self.metadata_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.metadata"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.metadata[0]"
         )
 
         self.modules_resource_name = "module.spacelift.module.s3.aws_s3_bucket.modules"
@@ -69,7 +69,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.modules"
         )
         self.modules_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.modules"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.modules[0]"
         )
         self.modules_replication_resource_name = "aws_s3_bucket_replication_configuration.modules"
 
@@ -82,7 +82,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.policy_inputs"
         )
         self.policy_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.policy_inputs"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.policy_inputs[0]"
         )
         self.policy_bucket_replication_resource_name = (
             "aws_s3_bucket_replication_configuration.policy_inputs"
@@ -99,7 +99,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.run_logs"
         )
         self.run_logs_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.run_logs"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.run_logs[0]"
         )
         self.run_logs_bucket_replication_resource_name = (
             "aws_s3_bucket_replication_configuration.run_logs"
@@ -113,7 +113,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_versioning.states"
         )
         self.states_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.states"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.states[0]"
         )
         self.states_bucket_replication_resource_name = (
             "aws_s3_bucket_replication_configuration.states"
@@ -130,7 +130,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.uploads"
         )
         self.uploads_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.uploads"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.uploads[0]"
         )
         self.uploads_cors_resource_name = (
             "module.spacelift.module.s3.aws_s3_bucket_cors_configuration.uploads[0]"
@@ -145,7 +145,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.user_uploads"
         )
         self.user_uploads_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.user_uploads"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.user_uploads[0]"
         )
 
         self.workspace_resource_name = "module.spacelift.module.s3.aws_s3_bucket.workspaces"
@@ -157,7 +157,7 @@ class S3Terraformer(Terraformer):
             "module.spacelift.module.s3.aws_s3_bucket_lifecycle_configuration.workspaces"
         )
         self.workspace_public_access_resource_name = (
-            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.workspaces"
+            "module.spacelift.module.s3.aws_s3_bucket_public_access_block.workspaces[0]"
         )
         self.workspace_bucket_replication_resource_name = (
             "aws_s3_bucket_replication_configuration.workspaces"

--- a/scanners/rds_scanner.py
+++ b/scanners/rds_scanner.py
@@ -34,4 +34,8 @@ def scan_rds_resources(session: boto3.Session, terraformer: RDSTerraformer) -> N
         if len(instances) != 1:
             raise Exception(f"Expected exactly one instance, but found {len(instances)}")
 
-        terraformer.rds_to_terraform(cluster, instances[0])
+        param_group = rds.describe_db_cluster_parameter_groups(
+            DBClusterParameterGroupName=cluster["DBClusterParameterGroup"]
+        )["DBClusterParameterGroups"][0]
+
+        terraformer.rds_to_terraform(cluster, instances[0], param_group)

--- a/utils/config.py
+++ b/utils/config.py
@@ -12,6 +12,7 @@ class DatabaseConfig:
     connection_string_ssm_arn: Optional[str] = None
     connection_string_ssm_kms_arn: Optional[str] = None
     backup_retention_period_days: Optional[str] = None
+    postgres_engine_version: Optional[str] = None
 
 
 @dataclass

--- a/utils/terraform_generator.py
+++ b/utils/terraform_generator.py
@@ -125,7 +125,7 @@ terraform {{
   required_providers {{
     aws = {{
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }}
   }}
 
@@ -177,9 +177,9 @@ def create_spacelift_module(unique_suffix: str, context: MigrationContext) -> st
   rds_engine_version              = "{context.rds_engine_version}"
   rds_preferred_backup_window     = "{context.rds_preferred_backup_window}"
   rds_regional_cluster_identifier = "spacelift"
-  rds_parameter_group_name        = "spacelift"
+  rds_parameter_group_name        = "{context.rds_parameter_group_name}"
   rds_subnet_group_name           = "spacelift"
-  rds_parameter_group_description = "Spacelift core product database"
+  rds_parameter_group_description = "{context.rds_parameter_group_description}"
   rds_password_sm_arn             = {get_db_password_arn(context)}
   rds_instance_configuration      = {{
     "primary" = {{
@@ -208,7 +208,7 @@ def create_spacelift_module(unique_suffix: str, context: MigrationContext) -> st
 
     return f"""        
 module "spacelift" {{
-  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v1.3.1"
+  source = "github.com/spacelift-io/terraform-aws-spacelift-selfhosted?ref=v2.1.1"
 
   region           = local.region
   website_endpoint = local.website_endpoint
@@ -238,10 +238,11 @@ module "spacelift" {{
   launcher_ecr_repository_name = "spacelift-launcher"
 
   security_group_names = {{
-    database  = "database_sg"
-    drain     = "drain_sg"
-    scheduler = "scheduler_sg"
-    server    = "server_sg"
+    database    = "database_sg"
+    drain       = "drain_sg"
+    scheduler   = "scheduler_sg"
+    server      = "server_sg"
+    vcs_gateway = "" # Mandatory, but leave it empty
   }}
         
 {rds_section}        
@@ -313,7 +314,7 @@ def create_spacelift_services_module(context: MigrationContext) -> str:
     return f"""
 # Uncomment after the above module applied successfully
 #module "spacelift_services" {{
-#  source = "github.com/spacelift-io/terraform-aws-ecs-spacelift-selfhosted?ref=v1.1.0"
+#  source = "github.com/spacelift-io/terraform-aws-ecs-spacelift-selfhosted?ref=v2.1.0"
 #  
 #  region               = local.region
 #  unique_suffix        = module.spacelift.unique_suffix


### PR DESCRIPTION
Bump the AWS Spacelift module to v2.1.1 and the ECS module to v2.1.0, along with upgrading the AWS provider constraint to ~> 6.0.

Key changes to match the newer module interfaces:
- S3 public access block resources now use `[0]` index
- RDS parameter group name and description are read from AWS instead of being hardcoded
- Add `vcs_gateway` to security group names (required by v2)
- Add compatibility matrix to README