### PR TITLE
chore: bump deprecated node20 GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run:  pip install -r requirements-dev.txt


### PR DESCRIPTION
Bumps GitHub Actions that were using the deprecated Node.js 20 runtime.

## Changes
- `actions/checkout@v4 → actions/checkout@v7`

## Why
Node.js 20 reached EOL in April 2026 and GitHub is deprecating it on Actions runners.
See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

> ⚠️ Actions with potentially breaking changes (custom configs, major API changes) are excluded and need manual review.

🤖 Generated with Claude Code